### PR TITLE
fix: add missing node command to inspector script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "tsc && node -e \"require('fs').chmodSync('build/client.js', '755')\"",
     "prepare": "npm run build",
     "watch": "tsc --watch",
-    "inspector": "npx @modelcontextprotocol/inspector build/client.js"
+    "inspector": "npx @modelcontextprotocol/inspector node build/client.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "0.6.0",


### PR DESCRIPTION
This small update was needed for the MCP Inspector to work.

P.S. This seems like a great tool. Thanks for putting it together!