### PR TITLE
Make server `npx`-runnable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,20 @@ Highly recommended to run locally, since AnkiConnect only works locally.
 
 Was only tested on windows.
 
-### To run locally:
+### Running locally via `npx`
+
+If you only wish to use the tool and not develop the tool,
+you may launch an MCP STDIO server locally using `npx`:
+
+```sh
+npx -y github:nietus/anki-mcp
+```
+
+This can be used in Desktop MCP clients such as Msty Studio or others.
+
+### Running locally via source code
+
+Alternatively, you can run locally via source code using these instructions:
 
 1. **Clone the repository:**
 

--- a/build/client.js
+++ b/build/client.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { YankiConnect } from "yanki-connect";

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { YankiConnect } from "yanki-connect";


### PR DESCRIPTION
This adds and documents `npx` compatibility.

Crucially, the cli script was missing a shebang.