### PR TITLE
Amend MCPB script to create an MCPB on more machines

### DIFF
--- a/scripts/create-mcpb.mjs
+++ b/scripts/create-mcpb.mjs
@@ -36,9 +36,12 @@ async function copyIfExists(source, destination) {
 async function runPack(directory, output) {
   await fsp.mkdir(path.dirname(output), { recursive: true });
   await new Promise((resolve, reject) => {
+
     const child = spawn(
-      "npx",
-      ["@anthropic-ai/mcpb", "pack", directory, output],
+      process.platform === "win32" ? "cmd" : "npx",
+      process.platform === "win32"
+        ? ["/c", "npx", "@anthropic-ai/mcpb", "pack", directory, output]
+        : ["@anthropic-ai/mcpb", "pack", directory, output],
       {
         cwd: rootDir,
         stdio: "inherit",


### PR DESCRIPTION
Could not get this Anki MCP to work on my machine, I made a little amendment locally and figured it would be worth merging into the actual project too. I've just updated the MCPB script to use `cmd` if Win32 is detected (and run a Win32 adjacent command), which, for me at least, resolved the problem on my Windows machine.

Before, it didn't seem to create the MCPB